### PR TITLE
feat(caching): add cache-control to json endpoint

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,11 @@ app.get('/.well-known/server-health', (req, res) => {
 // let's start with 30 minutes
 // need to research exact header names
 app.get('/', async (req, res) => {
+  // enable 30 minute cache when in AWS
+  if (config.app.environment !== 'development') {
+    res.set('Cache-control', 'public, max-age=1800');
+  }
+
   res.json(await getRecommendations());
 });
 


### PR DESCRIPTION
## Goal

add cache control header to cache results for 30 minutes (only when in AWS).

## Implementation Decisions

according to ian, the most often results would refresh is every hour. we're going with 30 minutes here as it seems still a very safe level of caching, and will invalidate faster than an hour just in case. i am very open to hearing opinions on different cache timeouts.