### PR TITLE
refactor(categories): use slate ids instead of descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,5 @@ Test are run via `npm` commands:
 
 #### Testing Client API
 
-Load up `http://localhost:4005` in your browser. There you go.
+- Run `npm start`.
+- Load up `http://localhost:4005` in your browser. There you go.

--- a/src/client-api-proxy.ts
+++ b/src/client-api-proxy.ts
@@ -39,7 +39,7 @@ export async function getRecommendations(): Promise<FAHRecommendationResponse> {
 
   if (data) {
     data.data.getSlateLineup.slates.forEach((slate: ClientApiSlate) => {
-      const category = deriveCategory(slate.description);
+      const category = deriveCategory(slate.id);
       recs = recs.concat(transformSlateRecs(slate.recommendations, category));
     });
   }
@@ -59,7 +59,7 @@ async function getData(): Promise<ClientApiResponse | null> {
       query Query($slateLineupId: String!, $slateCount: Int) {
         getSlateLineup(slateLineupId: $slateLineupId, slateCount: $slateCount) {
           slates {
-            description
+            id
             recommendations {
               item {
                 resolvedUrl

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,26 @@ export const config = {
     port: 4005,
     slateCount: 10, // this is the total number of slates in the lineup
     slateLineupId: 'a26db39b-a68a-4e01-b680-443a466f9c36',
+    // this results in a tight coupling between Recs API and this repo.
+    // this isn't great, but is the best as of now because:
+    // - it follows pre-existing Recs API practices of using a slate lineup
+    // - there are no plans to run experiments on this slate lineup,
+    //   meaning the ids below should not change
+    //
+    // if we end up wanting to run experiments on these recommendations, we
+    // would likely move to one slate lineup per category.
+    slateIdCategoryMap: {
+      '0737b00e-a21e-4875-a4c7-3e14926d4acf': 'general',
+      '2e3ddc90-8def-46d7-b85f-da7525c66fb1': 'must-reads',
+      '626397d3-fa4e-4299-8d07-cbeaa269ebc1': 'quick-reads',
+      'e0d7063a-9421-4148-b548-446e9fbc8566': 'technology',
+      '7cb4f497-fd05-42c5-9f78-3650e9ddba21': 'health',
+      '6d1273a5-055e-4de0-8a5b-5f2b79d37e5c': 'self-improvement',
+      '1a634351-361b-4115-a9d5-b79131b1f95a': 'food',
+      'b64c873e-7f05-496e-8be4-bfae929c8a04': 'science',
+      'e9df8a81-19af-48e2-a90f-05e9a37491ca': 'entertainment',
+      'b4032752-155b-4f09-ac1e-f5337df19e88': 'career',
+    },
     // TODO: check with petru on placeholder dimensions below & quality level
     imageCdnPrefix:
       'https://img-getpocket.cdn.mozilla.net/{wh}/filters:format(jpeg):quality(60):no_upscale():strip_exif()/',

--- a/src/lib.spec.ts
+++ b/src/lib.spec.ts
@@ -1,64 +1,19 @@
+import { config } from './config';
 import { deriveCategory, transformSlateRecs, buildCdnImageUrl } from './lib';
 import { FAHRecommendation, ClientApiRecommendation } from './types';
 
 describe('test lib', () => {
   describe('deriveCategory', () => {
-    // descriptions below are the descriptions returned from each slate from
-    // recommendation-api. why don't we use this map in the `deriveCategory`
-    // function itself? well, the idea behind creating a slatelineup is that we
-    // can swap out slates without changing code in this application - we just
-    // refer to the slatelineup. that being the case, checking on sub-strings
-    // in the `deriveCategory` function gives us a *bit* more resiliency if
-    // and when we change out the underlying slates.
-    //
-    // yes, it's still inherently brittle. :/
-    const slateDescriptionMap = [
-      {
-        category: 'general',
-        desc: 'Curated items including syndicated that are at most a week old',
-      },
-      {
-        category: 'quick-reads',
-        desc: 'Curated short reads excluding syndicated',
-      },
-      {
-        category: 'must-reads',
-        desc: 'Curated items excluding syndicated that are at most a week old',
-      },
-      {
-        category: 'technology',
-        desc: 'Curated Technology Slate',
-      },
-      {
-        category: 'health',
-        desc: 'Curated Health Slate',
-      },
-      {
-        category: 'self-improvement',
-        desc: 'Curated Self-Improvement Slate',
-      },
-      {
-        category: 'food',
-        desc: 'Curated Food Slate',
-      },
-      {
-        category: 'science',
-        desc: 'Curated Science Slate',
-      },
-      {
-        category: 'entertainment',
-        desc: 'Curated Entertainment Slate',
-      },
-      {
-        category: 'career',
-        desc: 'Curated Career Slate',
-      },
-    ];
-
     it('should derive the expected category from a slate description', () => {
-      slateDescriptionMap.forEach((map) => {
-        expect(deriveCategory(map.desc)).toEqual(map.category);
-      });
+      for (const prop in config.app.slateIdCategoryMap) {
+        expect(deriveCategory(prop)).toEqual(
+          config.app.slateIdCategoryMap[prop]
+        );
+      }
+    });
+
+    it('should return `general` for an un-mapped slate ID', () => {
+      expect(deriveCategory('some-unknown-slate-id')).toEqual('general');
     });
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,6 @@ export type ClientApiRecommendation = {
 };
 
 export type ClientApiSlate = {
-  description: string;
+  id: string;
   recommendations: ClientApiRecommendation[];
 };


### PR DESCRIPTION
## Goal

slate ids are a bit more stable than descriptions for deriving categories.

## Implementation Decisions

if an unknown slate ID is returned, default those recommendations to the `general` category.
