### PR TITLE
feat(alarms): add 5xx alarm

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -181,13 +181,15 @@ class FirefoxAndroidHomeRecommendations extends TerraformStack {
             ? [pagerDuty.snsNonCriticalAlarmTopic.arn]
             : [pagerDuty.snsCriticalAlarmTopic.arn],
         },
-        // will call your phone if latency >= 700ms once in a 5 minute period
+        // will call your phone if latency >= 700ms 3x in a 15 minute period
         httpLatency: {
           // making this threshold 700 because, on a cache miss, this service
           // will need to hit client API, which has to hit Recs API, so it the
           // response could be a little slow. results are cached for 30 minutes
+          // so if we get 3 high-latency requests in 15 minutes, something
+          // might be up with the cache (or downstream APIs).
           threshold: 700,
-          evaluationPeriods: 1,
+          evaluationPeriods: 3,
           period: 300,
           actions: config.isDev
             ? [pagerDuty.snsNonCriticalAlarmTopic.arn]

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -177,9 +177,7 @@ class FirefoxAndroidHomeRecommendations extends TerraformStack {
           threshold: 10,
           evaluationPeriods: 2,
           period: 600,
-          actions: config.isDev
-            ? [pagerDuty.snsNonCriticalAlarmTopic.arn]
-            : [pagerDuty.snsCriticalAlarmTopic.arn],
+          actions: config.isDev ? [] : [pagerDuty.snsCriticalAlarmTopic.arn],
         },
       },
     });

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -181,20 +181,6 @@ class FirefoxAndroidHomeRecommendations extends TerraformStack {
             ? [pagerDuty.snsNonCriticalAlarmTopic.arn]
             : [pagerDuty.snsCriticalAlarmTopic.arn],
         },
-        // will call your phone if latency >= 750ms 3x in a 15 minute period
-        httpLatency: {
-          // making this threshold 750 because, on a cache miss, this service
-          // will need to hit client API, which has to hit Recs API, so the
-          // response could be a little slow. results are cached for 30 minutes
-          // so if we get 3 high-latency requests in 15 minutes, something
-          // might be up with the cache (or downstream APIs).
-          threshold: 750,
-          evaluationPeriods: 3,
-          period: 300,
-          actions: config.isDev
-            ? [pagerDuty.snsNonCriticalAlarmTopic.arn]
-            : [pagerDuty.snsCriticalAlarmTopic.arn],
-        },
       },
     });
 

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -181,14 +181,14 @@ class FirefoxAndroidHomeRecommendations extends TerraformStack {
             ? [pagerDuty.snsNonCriticalAlarmTopic.arn]
             : [pagerDuty.snsCriticalAlarmTopic.arn],
         },
-        // will call your phone if latency >= 700ms 3x in a 15 minute period
+        // will call your phone if latency >= 750ms 3x in a 15 minute period
         httpLatency: {
-          // making this threshold 700 because, on a cache miss, this service
-          // will need to hit client API, which has to hit Recs API, so it the
+          // making this threshold 750 because, on a cache miss, this service
+          // will need to hit client API, which has to hit Recs API, so the
           // response could be a little slow. results are cached for 30 minutes
           // so if we get 3 high-latency requests in 15 minutes, something
           // might be up with the cache (or downstream APIs).
-          threshold: 700,
+          threshold: 750,
           evaluationPeriods: 3,
           period: 300,
           actions: config.isDev

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -172,17 +172,26 @@ class FirefoxAndroidHomeRecommendations extends TerraformStack {
         targetMaxCapacity: 10,
       },
       alarms: {
-        //TODO: When we start using this more we will change from non-critical to critical
+        // will call your phone if there are >= 10 5xx responses in 20 minutes
         http5xxError: {
           threshold: 10,
           evaluationPeriods: 2,
           period: 600,
-          actions: config.isDev ? [] : [],
+          actions: config.isDev
+            ? [pagerDuty.snsNonCriticalAlarmTopic.arn]
+            : [pagerDuty.snsCriticalAlarmTopic.arn],
         },
+        // will call your phone if latency >= 700ms once in a 5 minute period
         httpLatency: {
-          evaluationPeriods: 2,
-          threshold: 500,
-          actions: config.isDev ? [] : [],
+          // making this threshold 700 because, on a cache miss, this service
+          // will need to hit client API, which has to hit Recs API, so it the
+          // response could be a little slow. results are cached for 30 minutes
+          threshold: 700,
+          evaluationPeriods: 1,
+          period: 300,
+          actions: config.isDev
+            ? [pagerDuty.snsNonCriticalAlarmTopic.arn]
+            : [pagerDuty.snsCriticalAlarmTopic.arn],
         },
       },
     });


### PR DESCRIPTION
## Goal

add relevant alarms to the service.

please check the validity of the alarms configured, specifically the `httpLatency` alarm. do the parameters make sense?

## Implementation Decisions

not configuring an `HTTPRequestCount` alarm as we don't have an idea of request volume at this time. we could take a guess and make a non-critical alarm though. open to thoughts here.