### PR TITLE
fix(alarms): update 5xx alarm params and change to non-critical

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -8,7 +8,7 @@ const githubConnectionArn = isDev
 let environment;
 let domain;
 
-if (process.env.NODE_ENV === 'development') {
+if (isDev) {
   environment = 'Dev';
   domain = 'firefox-android-home-recommendations.getpocket.dev';
 } else {

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -172,12 +172,13 @@ class FirefoxAndroidHomeRecommendations extends TerraformStack {
         targetMaxCapacity: 10,
       },
       alarms: {
-        // will call your phone if there are >= 10 5xx responses in 20 minutes
+        // alarms if >= 25% of responses are 5xx responses for 20 minutes
         http5xxError: {
-          threshold: 10,
-          evaluationPeriods: 2,
-          period: 600,
-          actions: config.isDev ? [] : [pagerDuty.snsCriticalAlarmTopic.arn],
+          threshold: 25,
+          evaluationPeriods: 4,
+          period: 300,
+          // non-critical while we investigate current 5xx responses
+          actions: config.isDev ? [] : [pagerDuty.snsNonCriticalAlarmTopic.arn],
         },
       },
     });


### PR DESCRIPTION
## Goal

update `http5xxError` alarm to our current standards, and change to non-critical while we investigate cause(s) of current 5xx errors.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1056

## Implementation Decisions

