### PR TITLE
refactor(alarms): configure & enable http5xx alarm

### DIFF
--- a/.aws/package.json
+++ b/.aws/package.json
@@ -20,15 +20,15 @@
     "node": "=14"
   },
   "dependencies": {
-    "@pocket-tools/terraform-modules": "1.24.0",
-    "cdktf": "0.4.1",
-    "constructs": "3.2.100",
-    "@cdktf/provider-aws": "^1.0.122",
-    "@cdktf/provider-null": "^0.1.126"
+    "@cdktf/provider-aws": "2.0.10",
+    "@cdktf/provider-null": "0.2.7",
+    "@pocket-tools/terraform-modules": "1.27.1",
+    "cdktf": "0.5.0",
+    "constructs": "3.3.147"
   },
   "devDependencies": {
     "@types/node": "14.14.20",
-    "cdktf-cli": "0.4.1",
-    "typescript": "4.1.5"
+    "cdktf-cli": "0.6.0",
+    "typescript": "4.4.3"
   }
 }

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -173,12 +173,12 @@ class FirefoxAndroidHomeRecommendations extends TerraformStack {
       },
       alarms: {
         // alarms if >= 25% of responses are 5xx responses for 20 minutes
-        http5xxError: {
-          threshold: 25,
+        http5xxErrorPercentage: {
+          threshold: 25, // 25%
           evaluationPeriods: 4,
-          period: 300,
+          period: 300, // 5 minutes
           // non-critical while we investigate current 5xx responses
-          actions: config.isDev ? [] : [pagerDuty.snsNonCriticalAlarmTopic.arn],
+          actions: config.isDev ? [] : [pagerDuty.snsCriticalAlarmTopic.arn],
         },
       },
     });


### PR DESCRIPTION
## Goal

configure & enable http5xxErrorPercentage alarm. update terraform-modules & related packages.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1074
