### PR TITLE
Skip running 'terraform plan' on production when deploying to dev

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -54,7 +54,6 @@ phases:
       - tfenv install
       - tfenv use $(cat .terraform-version)
 
-      - npm install -g npm@latest
       - npm ci
       # synthesize the js into terraform json with the proper node environment
       - 'if [ "$GIT_BRANCH" == "$DEV_BRANCH" ]; then NODE_ENV=development npm run synth; else npm run synth; fi'


### PR DESCRIPTION
## Goal

Update the workflow to skip terraform plan when GIT_BRANCH is not empty since that is used for main and dev branch builds. Without this condition, deploying to the dev branch runs terraform plan against the production workspace.

## Todos
- [x] Update buildspec.yml 

Tickets:
-  https://getpocket.atlassian.net/browse/BACK-1178