### PR TITLE
chore(pagerduty):  [SOCIALPLAT-700] Remove this service from Tier 1 PagerDuty policy

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -60,8 +60,9 @@ class FirefoxAndroidHomeRecommendations extends TerraformStack {
     const pagerDuty = new PocketPagerDuty(this, 'pagerduty', {
       prefix: config.prefix,
       service: {
+        // This is a Tier 2 service and as such only raises non-critical alarms.
         criticalEscalationPolicyId: incidentManagement
-          .get('policy_default_critical_id')
+          .get('policy_default_non_critical_id')
           .toString(),
         nonCriticalEscalationPolicyId: incidentManagement
           .get('policy_default_non_critical_id')
@@ -178,7 +179,7 @@ class FirefoxAndroidHomeRecommendations extends TerraformStack {
           evaluationPeriods: 4,
           period: 300, // 5 minutes
           // non-critical while we investigate current 5xx responses
-          actions: config.isDev ? [] : [pagerDuty.snsCriticalAlarmTopic.arn],
+          actions: config.isDev ? [] : [pagerDuty.snsNonCriticalAlarmTopic.arn],
         },
       },
     });


### PR DESCRIPTION
## Goal
 
Remove this service from Tier 1 PagerDuty policy. Additionally, downgrade the one critical alarm to a non-critical one.

## References

JIRA ticket:
* https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-700

