### PR TITLE
MC-1553: use pocket/circleci-orbs@2.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-ecs: circleci/aws-ecs@3.2.0
-  pocket: pocket/circleci-orbs@2.2.0
+  pocket: pocket/circleci-orbs@2.3.0
   backstage-entity-validator: roadiehq/backstage-entity-validator@0.4.2
 
 # Workflow shortcuts
@@ -106,6 +106,7 @@ workflows:
           aws-access-key-id: Dev_AWS_ACCESS_KEY
           aws-secret-access-key: Dev_AWS_SECRET_ACCESS_KEY
           aws-region: Dev_AWS_DEFAULT_REGION
+          aws-account-id: '410318598490'
           repo-name: firefoxandroidhomerecommendations-dev-app
           ecr-url: 410318598490.dkr.ecr.us-east-1.amazonaws.com
           push: false
@@ -120,6 +121,7 @@ workflows:
           aws-access-key-id: Dev_AWS_ACCESS_KEY
           aws-secret-access-key: Dev_AWS_SECRET_ACCESS_KEY
           aws-region: Dev_AWS_DEFAULT_REGION
+          aws-account-id: '410318598490'
           codebuild-project-name: FirefoxAndroidHomeRecommendations-Dev
           codebuild-project-branch: dev
           repo-name: firefoxandroidhomerecommendations-dev-app
@@ -152,6 +154,7 @@ workflows:
           aws-access-key-id: Prod_AWS_ACCESS_KEY
           aws-secret-access-key: Prod_AWS_SECRET_ACCESS_KEY
           aws-region: Prod_AWS_DEFAULT_REGION
+          aws-account-id: '996905175585'
           codebuild-project-name: FirefoxAndroidHomeRecommendations-Prod
           codebuild-project-branch: main
           repo-name: firefoxandroidhomerecommendations-prod-app


### PR DESCRIPTION
# Goal

Use the new pocket/circleci-orbs@2.3.0 with the updated aws-ecr orb & build_docker job.

## Todos
- [x] deployed to dev

## Reference

Tickets:
* https://mozilla-hub.atlassian.net/browse/MC-1553