### PR TITLE
fix: infrastructure build fails

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -1,7 +1,6 @@
 import { Construct } from 'constructs';
 import {
   App,
-  DataTerraformRemoteState,
   S3Backend,
   TerraformStack,
 } from 'cdktf';
@@ -42,27 +41,13 @@ class FirefoxAndroidHomeRecommendations extends TerraformStack {
       key: config.name,
       region: 'us-east-1',
     });
-    const incidentManagement = new DataTerraformRemoteState(
-      this,
-      'incident_management',
-      {
-        organization: 'Pocket',
-        workspaces: {
-          name: 'incident-management',
-        },
-      },
-    );
 
     const pagerDuty = new PocketPagerDuty(this, 'pagerduty', {
       prefix: config.prefix,
       service: {
         // This is a Tier 2 service and as such only raises non-critical alarms.
-        criticalEscalationPolicyId: incidentManagement
-          .get('policy_default_non_critical_id')
-          .toString(),
-        nonCriticalEscalationPolicyId: incidentManagement
-          .get('policy_default_non_critical_id')
-          .toString(),
+        criticalEscalationPolicyId: 'PXOQVEP',
+        nonCriticalEscalationPolicyId: 'PXOQVEP',
       },
     });
 


### PR DESCRIPTION
## Goal
Fix tf plan failing:

```
Error: Unable to find remote state

  with data.terraform_remote_state.incident_management,
  on cdk.tf.json line 511, in data.terraform_remote_state.incident_management:
 511:       }
No stored state was found for the given workspace in the given backend.
```

## Reference

- [Slack thread](https://mozilla.slack.com/archives/C058SAB9F0Q/p1748889469296409)
- Example PR: https://github.com/Pocket/content-monorepo/pull/253
